### PR TITLE
Use bound constraints for composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
         "php": ">=5.4",
         "behat/behat": "^3.0.0",
         "behat/mink-extension": "^2.0.0",
-        "bex/behat-extension-driver-locator": "*",
+        "bex/behat-extension-driver-locator": "^1.0",
         "symfony/filesystem": "^2.7"
     },
     "require-dev": {
-        "bex/behat-test-runner": "*",
+        "bex/behat-test-runner": "^1.0",
         "phpspec/phpspec": "2.4.0-alpha2",
         "jakoch/phantomjs-installer": "^1.9.8",
         "behat/mink-selenium2-driver": "^1.3.0",
-        "bex/behat-screenshot-image-driver-dummy": "*"
+        "bex/behat-screenshot-image-driver-dummy": "^1.0"
     },
     "suggest": {
         "bex/behat-screenshot-image-driver-uploadpie": "Allows to upload the screenshot to uploadpie.com",


### PR DESCRIPTION
Unbound constraints are bad, especially in released versions (as it means you should never break BC in the dependency, which you cannot guarantee