### PR TITLE
Use a prefix for the composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "autoload": {
         "psr-0": {
-            "": "src"
+            "Bex\\Behat\\ScreenshotExtension\\": "src"
         }
     },
     "scripts": {


### PR DESCRIPTION
The prefix avoids that Composer looks in this package for any class of other packages when using a non-optimized autoloader (very common in dev, and this Behat extension is meant to be used in dev environments). checking a prefix is much faster than performing IO to check the presence of a file.