### PR TITLE
Catch exception in takeSceenshot method

### DIFF
--- a/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
+++ b/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
@@ -43,11 +43,15 @@ class ScreenshotTaker
      */
     public function takeScreenshot($fileName = 'failure.png')
     {
-        $screenshot = $this->mink->getSession()->getScreenshot();
-
-        foreach ($this->imageDrivers as $imageDriver) {
-            $imageUrl = $imageDriver->upload($screenshot, $fileName);
-            $this->output->writeln('Screenshot has been taken. Open image at ' . $imageUrl);
-        }
+        try {
+            $screenshot = $this->mink->getSession()->getScreenshot();
+            
+            foreach ($this->imageDrivers as $imageDriver) {
+                $imageUrl = $imageDriver->upload($screenshot, $fileName);
+                $this->output->writeln('Screenshot has been taken. Open image at ' . $imageUrl);
+            }
+        } catch (\Exception $e) {
+            $this->output->writeln($e->getMessage());
+        }        
     }
 }


### PR DESCRIPTION
Catch mink driver and screenshot image driver exceptions, e.g. `UnsupportedDriverActionException` or `DriverException` can be thrown if the screenshot cannot be taken by the driver or curl exception / file system related exception can be thrown when the image cannot be uploaded/saved. We should not block the test runnning when the screenshot extension failed to create the screenshot.