### PR TITLE
Fixing output printer - newest behat version use Output Factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "behat/behat": "^3.0.0",
+        "behat/behat": "^3.1.0",
         "behat/mink-extension": "^2.0.0",
         "bex/behat-extension-driver-locator": "^1.0.2",
         "symfony/filesystem": "^2.7|^3.0"
@@ -29,7 +29,7 @@
     "require-dev": {
         "bex/behat-test-runner": "^1.0",
         "phpspec/phpspec": "2.4.0-alpha2",
-        "jakoch/phantomjs-installer": "^1.9.8",
+        "jakoch/phantomjs-installer": "^2.1.1",
         "behat/mink-selenium2-driver": "^1.3.0",
         "bex/behat-screenshot-image-driver-dummy": "^1.0"
     },

--- a/spec/Bex/Behat/ScreenshotExtension/Service/ScreenshotTakerSpec.php
+++ b/spec/Bex/Behat/ScreenshotExtension/Service/ScreenshotTakerSpec.php
@@ -6,8 +6,8 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Behat\Mink\Mink;
 use Behat\Mink\Session;
-use Behat\Testwork\Output\Printer\OutputPrinter;
 use Bex\Behat\ScreenshotExtension\Driver\Local;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**
  * Unit test of the class ScreenshotTaker
@@ -16,7 +16,8 @@ use Bex\Behat\ScreenshotExtension\Driver\Local;
  */
 class ScreenshotTakerSpec extends ObjectBehavior
 {
-    function let(Mink $mink, OutputPrinter $output, Local $localImageDriver)
+
+    function let(Mink $mink, ConsoleOutput $output, Local $localImageDriver)
     {
         $this->beConstructedWith($mink, $output, [$localImageDriver]);
     }

--- a/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
+++ b/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
@@ -3,9 +3,9 @@
 namespace Bex\Behat\ScreenshotExtension\Service;
 
 use Behat\Mink\Mink;
-use Behat\Testwork\Output\Printer\OutputPrinter;
+use Behat\Testwork\Output\Printer\StreamOutputPrinter;
 use Bex\Behat\ScreenshotExtension\Driver\ImageDriverInterface;
-
+use Behat\Testwork\Output\Printer\Factory\ConsoleOutputFactory;
 /**
  * This class is responsible for taking screenshot by using the Mink session
  *
@@ -16,24 +16,28 @@ class ScreenshotTaker
     /** @var Mink $mink */
     private $mink;
 
-    /** @var OutputPrinter $output */
+    /** @var ConsoleOutputFactory $output */
     private $output;
 
     /** @var ImageDriverInterface[] $imageDrivers */
     private $imageDrivers;
 
+    /** @var StreamOutputPrinter $outputStream */
+    private $outputStream;
+    
     /**
      * Constructor
      *
      * @param Mink $mink
-     * @param OutputPrinter $output
+     * @param StreamOutputPrinter $output
      * @param ImageDriverInterface[] $imageDrivers
      */
-    public function __construct(Mink $mink, OutputPrinter $output, array $imageDrivers)
+    public function __construct(Mink $mink, ConsoleOutputFactory $output, array $imageDrivers)
     {
         $this->mink = $mink;
         $this->output = $output;
         $this->imageDrivers = $imageDrivers;
+        $this->outputStream = new StreamOutputPrinter ($output);
     }
 
     /**
@@ -45,13 +49,13 @@ class ScreenshotTaker
     {
         try {
             $screenshot = $this->mink->getSession()->getScreenshot();
-            
+
             foreach ($this->imageDrivers as $imageDriver) {
                 $imageUrl = $imageDriver->upload($screenshot, $fileName);
-                $this->output->writeln('Screenshot has been taken. Open image at ' . $imageUrl);
+                $this->outputStream->writeln('Screenshot has been taken. Open image at ' . $imageUrl);
             }
         } catch (\Exception $e) {
-            $this->output->writeln($e->getMessage());
-        }        
+            $this->outputStream->writeln($e->getMessage());
+        }
     }
 }

--- a/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
+++ b/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
@@ -26,7 +26,7 @@ class ScreenshotTaker
      * Constructor
      *
      * @param Mink $mink
-     * @param ConsoleOutputFactory $output
+     * @param ConsoleOutput $output
      * @param ImageDriverInterface[] $imageDrivers
      */
     public function __construct(Mink $mink, ConsoleOutput $output, array $imageDrivers)

--- a/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
+++ b/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
@@ -3,9 +3,9 @@
 namespace Bex\Behat\ScreenshotExtension\Service;
 
 use Behat\Mink\Mink;
-use Behat\Testwork\Output\Printer\StreamOutputPrinter;
 use Bex\Behat\ScreenshotExtension\Driver\ImageDriverInterface;
-use Behat\Testwork\Output\Printer\Factory\ConsoleOutputFactory;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
 /**
  * This class is responsible for taking screenshot by using the Mink session
  *
@@ -16,28 +16,24 @@ class ScreenshotTaker
     /** @var Mink $mink */
     private $mink;
 
-    /** @var ConsoleOutputFactory $output */
+    /** @var ConsoleOutput $output */
     private $output;
 
     /** @var ImageDriverInterface[] $imageDrivers */
     private $imageDrivers;
-
-    /** @var StreamOutputPrinter $outputStream */
-    private $outputStream;
     
     /**
      * Constructor
      *
      * @param Mink $mink
-     * @param StreamOutputPrinter $output
+     * @param ConsoleOutputFactory $output
      * @param ImageDriverInterface[] $imageDrivers
      */
-    public function __construct(Mink $mink, ConsoleOutputFactory $output, array $imageDrivers)
+    public function __construct(Mink $mink, ConsoleOutput $output, array $imageDrivers)
     {
         $this->mink = $mink;
         $this->output = $output;
         $this->imageDrivers = $imageDrivers;
-        $this->outputStream = new StreamOutputPrinter ($output);
     }
 
     /**
@@ -52,10 +48,10 @@ class ScreenshotTaker
 
             foreach ($this->imageDrivers as $imageDriver) {
                 $imageUrl = $imageDriver->upload($screenshot, $fileName);
-                $this->outputStream->writeln('Screenshot has been taken. Open image at ' . $imageUrl);
+                $this->output->writeln('Screenshot has been taken. Open image at ' . $imageUrl);
             }
         } catch (\Exception $e) {
-            $this->outputStream->writeln($e->getMessage());
+            $this->output->writeln($e->getMessage());
         }
     }
 }

--- a/src/Bex/Behat/ScreenshotExtension/ServiceContainer/config/services.xml
+++ b/src/Bex/Behat/ScreenshotExtension/ServiceContainer/config/services.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="bex.screenshot_extension.output_printer" class="Behat\Testwork\Output\Printer\Factory\ConsoleOutputFactory" />
+        <service id="bex.screenshot_extension.output_printer" class="Symfony\Component\Console\Output\ConsoleOutput" />
 
         <service id="bex.screenshot_extension.step_filename_generator" class="Bex\Behat\ScreenshotExtension\Service\StepFilenameGenerator" public="false" />
 

--- a/src/Bex/Behat/ScreenshotExtension/ServiceContainer/config/services.xml
+++ b/src/Bex/Behat/ScreenshotExtension/ServiceContainer/config/services.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="bex.screenshot_extension.output_printer" class="Behat\Testwork\Output\Printer\ConsoleOutputPrinter" />
+        <service id="bex.screenshot_extension.output_printer" class="Behat\Testwork\Output\Printer\Factory\ConsoleOutputFactory" />
 
         <service id="bex.screenshot_extension.step_filename_generator" class="Bex\Behat\ScreenshotExtension\Service\StepFilenameGenerator" public="false" />
 


### PR DESCRIPTION
Behat 3.1.0 started using OutputFactories, if someone tries to use BEX with newest behat this results in error because BEX is still using OutputPrinter class. Switched to StreamOutputPrinter and fixed the issue. 