### PR TITLE
Feature/console output refinement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ php: [5.4, 5.5, 5.6, 7.0, hhvm]
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: 7.0
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "behat/behat": "^3.0.0",
         "behat/mink-extension": "^2.0.0",
         "bex/behat-extension-driver-locator": "^1.0.2",
-        "symfony/filesystem": "^2.7|^3.0",
-        "symfony/console": "^2.0|^3.0"
+        "symfony/filesystem": "^2.7|^3.0"
     },
     "require-dev": {
         "bex/behat-test-runner": "^1.0",

--- a/features/bootstrap/ScreenshotContext.php
+++ b/features/bootstrap/ScreenshotContext.php
@@ -105,6 +105,10 @@ class ScreenshotContext implements SnippetAcceptingContext
     private static function removeTempDirs(array $directories)
     {
         foreach ($directories as $directory) {
+            if (!is_dir($directory)) {
+                continue;
+            }
+
             $fileIterator = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator(
                     $directory,

--- a/spec/Bex/Behat/ScreenshotExtension/Output/IndentedOutputSpec.php
+++ b/spec/Bex/Behat/ScreenshotExtension/Output/IndentedOutputSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace spec\Bex\Behat\ScreenshotExtension\Output;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IndentedOutputSpec extends ObjectBehavior
+{
+    function it_indents_message_with_six_space_by_default(OutputInterface $decoratedOutput)
+    {
+        $this->beConstructedWith($decoratedOutput);
+
+        $decoratedOutput->write('      Hello!', Argument::cetera())->shouldBeCalled();
+        $decoratedOutput->writeln('      Hello!', Argument::cetera())->shouldBeCalled();
+
+        $this->write('Hello!');
+        $this->writeln('Hello!');
+    }
+
+    function it_indents_message_with_custom_levels_and_character(OutputInterface $decoratedOutput)
+    {
+        $this->beConstructedWith($decoratedOutput, 2, '-');
+
+        $decoratedOutput->write('----Hello!', Argument::cetera())->shouldBeCalled();
+        $decoratedOutput->writeln('----Hello!', Argument::cetera())->shouldBeCalled();
+
+        $this->write('Hello!');
+        $this->writeln('Hello!');
+    }
+}

--- a/src/Bex/Behat/ScreenshotExtension/Output/IndentedOutput.php
+++ b/src/Bex/Behat/ScreenshotExtension/Output/IndentedOutput.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Bex\Behat\ScreenshotExtension\Output;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+/**
+ * Class IndentedOutput
+ *
+ * @package Bex\Behat\ScreenshotExtension\Output
+ *
+ * @author Geza Buza <bghome@gmail.com>
+ */
+class IndentedOutput implements OutputInterface
+{
+    const INDENT_WIDTH = 2;
+
+    const DEFAULT_INDENT_LEVEL = 3;
+    const DEFAULT_INDENT_CHARACTER = ' ';
+
+    /**
+     * @var string String being appended to the message
+     */
+    private $indentation;
+
+    /**
+     * @var OutputInterface
+     */
+    private $decoratedOutput;
+
+    /**
+     * IndentedOutput constructor.
+     *
+     * @param OutputInterface $decoratedOutput
+     * @param int $indentLevel
+     * @param string $indentCharacter
+     */
+    public function __construct(
+        OutputInterface $decoratedOutput,
+        $indentLevel = self::DEFAULT_INDENT_LEVEL,
+        $indentCharacter = self::DEFAULT_INDENT_CHARACTER
+    ) {
+        $this->indentation = str_repeat($indentCharacter, $indentLevel * self::INDENT_WIDTH);
+        $this->decoratedOutput = $decoratedOutput;
+    }
+
+    /**
+     * Writes a message to the output.
+     *
+     * @param string|array $messages The message as an array of lines or a single string
+     * @param bool $newline Whether to add a newline
+     * @param int $options A bitmask of options (one of the OUTPUT or VERBOSITY constants), 0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
+     */
+    public function write($messages, $newline = false, $options = 0)
+    {
+        $messages = $this->addIndentationToMessages($messages);
+
+        $this->decoratedOutput->write($messages, $newline, $options);
+    }
+
+    /**
+     * Writes a message to the output and adds a newline at the end.
+     *
+     * @param string|array $messages The message as an array of lines of a single string
+     * @param int $options A bitmask of options (one of the OUTPUT or VERBOSITY constants), 0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
+     */
+    public function writeln($messages, $options = 0)
+    {
+        $messages = $this->addIndentationToMessages($messages);
+
+        $this->decoratedOutput->writeln($messages, $options);
+    }
+
+    /**
+     * Sets the verbosity of the output.
+     *
+     * @param int $level The level of verbosity (one of the VERBOSITY constants)
+     */
+    public function setVerbosity($level)
+    {
+        $this->decoratedOutput->setVerbosity($level);
+    }
+
+    /**
+     * Gets the current verbosity of the output.
+     *
+     * @return int The current level of verbosity (one of the VERBOSITY constants)
+     */
+    public function getVerbosity()
+    {
+        return $this->decoratedOutput->getVerbosity();
+    }
+
+    /**
+     * Returns whether verbosity is quiet (-q).
+     *
+     * @return bool true if verbosity is set to VERBOSITY_QUIET, false otherwise
+     */
+    public function isQuiet()
+    {
+        return $this->decoratedOutput->isQuiet();
+    }
+
+    /**
+     * Returns whether verbosity is verbose (-v).
+     *
+     * @return bool true if verbosity is set to VERBOSITY_VERBOSE, false otherwise
+     */
+    public function isVerbose()
+    {
+        return $this->decoratedOutput->isVerbose();
+    }
+
+    /**
+     * Returns whether verbosity is very verbose (-vv).
+     *
+     * @return bool true if verbosity is set to VERBOSITY_VERY_VERBOSE, false otherwise
+     */
+    public function isVeryVerbose()
+    {
+        return $this->decoratedOutput->isVeryVerbose();
+    }
+
+    /**
+     * Returns whether verbosity is debug (-vvv).
+     *
+     * @return bool true if verbosity is set to VERBOSITY_DEBUG, false otherwise
+     */
+    public function isDebug()
+    {
+        return $this->decoratedOutput->isDebug();
+    }
+
+    /**
+     * Sets the decorated flag.
+     *
+     * @param bool $decorated Whether to decorate the messages
+     */
+    public function setDecorated($decorated)
+    {
+        $this->decoratedOutput->setDecorated($decorated);
+    }
+
+    /**
+     * Gets the decorated flag.
+     *
+     * @return bool true if the output will decorate messages, false otherwise
+     */
+    public function isDecorated()
+    {
+        return $this->decoratedOutput->isDecorated();
+    }
+
+    /**
+     * Sets output formatter.
+     *
+     * @param \Symfony\Component\Console\Formatter\OutputFormatterInterface $formatter
+     */
+    public function setFormatter(\Symfony\Component\Console\Formatter\OutputFormatterInterface $formatter)
+    {
+        $this->decoratedOutput->setFormatter($formatter);
+    }
+
+    /**
+     * Returns current output formatter instance.
+     *
+     * @return \Symfony\Component\Console\Formatter\OutputFormatterInterface
+     */
+    public function getFormatter()
+    {
+        return $this->decoratedOutput->getFormatter();
+    }
+
+    /**
+     * Prepend message with padding
+     * 
+     * @param $messages
+     *
+     * @return array|string
+     */
+    private function addIndentationToMessages($messages)
+    {
+        if (is_array($messages)) {
+            array_walk(
+                $messages,
+                function ($message) {
+                    return $this->indentation . $message;
+                }
+            );
+            return $messages;
+        } else {
+            $messages = $this->indentation . $messages;
+            return $messages;
+        }
+    }
+}

--- a/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
+++ b/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
@@ -4,7 +4,6 @@ namespace Bex\Behat\ScreenshotExtension\Service;
 
 use Behat\Mink\Mink;
 use Bex\Behat\ScreenshotExtension\Driver\ImageDriverInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
+++ b/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
@@ -48,10 +48,24 @@ class ScreenshotTaker
             
             foreach ($this->imageDrivers as $imageDriver) {
                 $imageUrl = $imageDriver->upload($screenshot, $fileName);
-                $this->output->writeln('Screenshot has been taken. Open image at ' . $imageUrl);
+                $this->printImageLocation($imageUrl);
             }
         } catch (\Exception $e) {
             $this->output->writeln($e->getMessage());
         }        
+    }
+
+    /**
+     * @param string $imageUrl
+     */
+    private function printImageLocation($imageUrl)
+    {
+        $message = sprintf(
+            '<comment>Screenshot has been taken. Open image at <error>%s</error></comment>',
+            $imageUrl
+        );
+        $options = $this->output->isDecorated() ? OutputInterface::OUTPUT_NORMAL : OutputInterface::OUTPUT_PLAIN;
+        
+        $this->output->writeln($message, $options);
     }
 }

--- a/src/Bex/Behat/ScreenshotExtension/ServiceContainer/config/services.xml
+++ b/src/Bex/Behat/ScreenshotExtension/ServiceContainer/config/services.xml
@@ -3,13 +3,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="bex.screenshot_extension.output_printer" class="Symfony\Component\Console\Output\ConsoleOutput" />
-
         <service id="bex.screenshot_extension.step_filename_generator" class="Bex\Behat\ScreenshotExtension\Service\StepFilenameGenerator" public="false" />
 
         <service id="bex.screenshot_extension.screenshot_taker" class="Bex\Behat\ScreenshotExtension\Service\ScreenshotTaker" public="false">
             <argument type="service" id="mink" />
-            <argument type="service" id="bex.screenshot_extension.output_printer" />
+            <argument type="service" id="cli.output" />
             <argument>%bex.screenshot_extension.active_image_drivers%</argument>
         </service>
 

--- a/src/Bex/Behat/ScreenshotExtension/ServiceContainer/config/services.xml
+++ b/src/Bex/Behat/ScreenshotExtension/ServiceContainer/config/services.xml
@@ -5,9 +5,13 @@
     <services>
         <service id="bex.screenshot_extension.step_filename_generator" class="Bex\Behat\ScreenshotExtension\Service\StepFilenameGenerator" public="false" />
 
+        <service id="bex.screenshot_extension.indented_output" class="Bex\Behat\ScreenshotExtension\Output\IndentedOutput" public="false">
+            <argument type="service" id="cli.output" />
+        </service>
+
         <service id="bex.screenshot_extension.screenshot_taker" class="Bex\Behat\ScreenshotExtension\Service\ScreenshotTaker" public="false">
             <argument type="service" id="mink" />
-            <argument type="service" id="cli.output" />
+            <argument type="service" id="bex.screenshot_extension.indented_output" />
             <argument>%bex.screenshot_extension.active_image_drivers%</argument>
         </service>
 


### PR DESCRIPTION
This PR delivers the following improvements:

- Symfony console component is not required to be directly installed by Composer (replaced by "cli.output" service from Behat)
- Output is coloured if console supports ANSI characters (see --color and --no-color switches)
- Indentation is added to every line to make the message look a bit better