### PR TITLE
Support clearing local screenshot directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ default:
       image_drivers:
         local:
           screenshot_directory: /your/desired/path/for/screenshots
+          clear_screenshot_directory: true  # Enable removing all images before each test run. It is false by default.
 ```
 
 If you are using another image driver you can enable it like this:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "behat/behat": "^3.0.0",
         "behat/mink-extension": "^2.0.0",
         "bex/behat-extension-driver-locator": "^1.0.2",
-        "symfony/filesystem": "^2.7|^3.0"
+        "symfony/filesystem": "^2.7|^3.0",
+        "symfony/finder": "^2.7|^3.0"
     },
     "require-dev": {
         "bex/behat-test-runner": "^1.0",

--- a/features/bootstrap/ScreenshotContext.php
+++ b/features/bootstrap/ScreenshotContext.php
@@ -73,6 +73,35 @@ class ScreenshotContext implements SnippetAcceptingContext
     }
 
     /**
+     * @Given I have an image :image file in :directory directory
+     */
+    public function iHaveAnImageFileInDirectory($image, $directory)
+    {
+        $filename = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $image;
+        $this->createDirectory($directory);
+        $this->createDummyImage($filename);
+    }
+
+    /**
+     * @Given the only file in :directory directory should be :filename
+     */
+    public function theOnlyFileInDirectoryShouldBe($directory, $filename)
+    {
+        $files = glob(rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*');
+
+        if (count($files) > 1 || array_search($filename, $files) === false) {
+            throw new RuntimeException(
+                sprintf(
+                    'Only file "%s" is expected to be in "%s" directory, but %d files found.',
+                    $filename,
+                    $directory,
+                    count($files)
+                )
+            );
+        }
+    }
+
+    /**
      * @AfterSuite
      */
     public static function cleanUp()
@@ -123,5 +152,19 @@ class ScreenshotContext implements SnippetAcceptingContext
 
             rmdir($directory);
         }
+    }
+
+    private function createDirectory($directory)
+    {
+        $filesystem = new \Symfony\Component\Filesystem\Filesystem();
+        if (!$filesystem->exists($directory)) {
+            $filesystem->mkdir($directory);
+        }
+    }
+
+    private function createDummyImage($saveAsFile)
+    {
+        $base64Image = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQIW2P4//8/AAX+Av6hN/6/AAAAAElFTkSuQmCC';
+        file_put_contents($saveAsFile, base64_decode($base64Image));
     }
 }

--- a/features/screenshot-taking.feature
+++ b/features/screenshot-taking.feature
@@ -131,3 +131,27 @@ Feature: Taking screenshot
       """
     When I run Behat
     Then I should not see the message "Screenshot has been taken."
+
+  Scenario: Clear local screenshot directory before running the tests
+    Given I have the configuration:
+      """
+      default:
+        extensions:
+          Behat\MinkExtension:
+            base_url: 'http://localhost:8080'
+            sessions:
+              default:
+                selenium2:
+                  wd_host: http://localhost:4444/wd/hub
+                  browser: phantomjs
+
+          Bex\Behat\ScreenshotExtension:
+            image_drivers:
+              local:
+                screenshot_directory: /tmp/behat-screenshot-custom/
+                clear_screenshot_directory: true
+      """
+    And I have an image "dummy.png" file in "/tmp/behat-screenshot-custom/" directory
+    When I run Behat
+    Then I should see a failing test
+    And the only file in "/tmp/behat-screenshot-custom/" directory should be "/tmp/behat-screenshot-custom/i_have_a_failing_step.png"

--- a/spec/Bex/Behat/ScreenshotExtension/Driver/LocalSpec.php
+++ b/spec/Bex/Behat/ScreenshotExtension/Driver/LocalSpec.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace spec\Bex\Behat\ScreenshotExtension\Driver;
+
+use Bex\Behat\ScreenshotExtension\Driver\Local;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Prophecy\Prophet;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+class LocalSpec extends ObjectBehavior
+{
+    function let(Filesystem $filesystem, Finder $finder, \finfo $fileInfo)
+    {
+        $this->beConstructedWith($filesystem, $finder, $fileInfo);
+
+        $this->initializeFinderStub($finder);
+        $this->initializeFileInfoStub($fileInfo);
+    }
+
+    function it_cleans_up_screenshot_directory_when_switch_is_on(
+        Filesystem $filesystem, Finder $finder, ContainerBuilder $container
+    ) {
+        $config = $this->getDefaultConfig();
+        $config[Local::CONFIG_PARAM_CLEAR_SCREENSHOT_DIRECTORY] = true;
+        $images = ['a.png', 'b.png'];
+        $files = [];
+        $prophet = new Prophet;
+
+        foreach ($images as $image) {
+            $splFileInfo = $prophet->prophesize('\SplFileInfo');
+            $splFileInfo->getRealPath()->willReturn($image);
+            $files[] = $splFileInfo;
+        }
+        $finder->in(Argument::type('string'))->willReturn($files);
+
+        $filesystem->remove($images)->shouldBeCalled();
+
+        $this->load($container, $config);
+    }
+
+    function it_does_not_clean_up_screenshot_directory_when_switch_is_off(
+        Filesystem $filesystem, Finder $finder, ContainerBuilder $container
+    ) {
+        $config = $this->getDefaultConfig();
+        $config[Local::CONFIG_PARAM_CLEAR_SCREENSHOT_DIRECTORY] = false;
+        $images = ['a.png', 'b.png'];
+        $files = [];
+        $prophet = new Prophet;
+
+        foreach ($images as $image) {
+            $splFileInfo = $prophet->prophesize('\SplFileInfo');
+            $splFileInfo->getRealPath()->willReturn($image);
+            $files[] = $splFileInfo;
+        }
+        $finder->in(Argument::type('string'))->willReturn($files);
+
+        $filesystem->remove(Argument::any())->shouldNotBeCalled();
+
+        $this->load($container, $config);
+    }
+
+    function it_removes_only_image_files(
+        Filesystem $filesystem, Finder $finder, ContainerBuilder $container, \finfo $fileInfo
+    ) {
+        $config = $this->getDefaultConfig();
+        $config[Local::CONFIG_PARAM_CLEAR_SCREENSHOT_DIRECTORY] = true;
+        $images = ['a.png', 'b.png'];
+        $nonImages = ['c.png', 'd.txt'];
+        $files = [];
+        $prophet = new Prophet;
+
+        foreach (array_merge($images, $nonImages) as $filename) {
+            $splFileInfo = $prophet->prophesize('\SplFileInfo');
+            $splFileInfo->getRealPath()->willReturn($filename);
+            $files[] = $splFileInfo;
+        }
+        $finder->in(Argument::type('string'))->willReturn($files);
+
+        foreach ($nonImages as $filename) {
+            $fileInfo->file($filename, FILEINFO_MIME_TYPE)->willReturn('plain/text');
+        }
+
+        $filesystem->remove($images)->shouldBeCalled();
+
+        $this->load($container, $config);
+    }
+
+    private function initializeFinderStub(Finder $finder)
+    {
+        $finder->files()->willReturn($finder);
+    }
+
+    private function initializeFileInfoStub(\finfo $fileInfo)
+    {
+        $fileInfo->file(Argument::type('string'), FILEINFO_MIME_TYPE)->willReturn('image/png');
+    }
+
+    /**
+     * @return array
+     */
+    private function getDefaultConfig()
+    {
+        $config = [
+            Local::CONFIG_PARAM_SCREENSHOT_DIRECTORY       => '/path/to/screenshots/',
+            Local::CONFIG_PARAM_CLEAR_SCREENSHOT_DIRECTORY => false,
+        ];
+        return $config;
+    }
+}


### PR DESCRIPTION
This commit adds the screenshot clearing feature to the local image driver.
When turned on all image files will be removed from the configured local screenshot directory.
The feature is turned off by default.