### PR TITLE
Declare php extension Fileinfo as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "behat/mink-extension": "^2.0.0",
         "bex/behat-extension-driver-locator": "^1.0.2",
         "symfony/filesystem": "^2.7|^3.0",
-        "symfony/finder": "^2.7|^3.0"
+        "symfony/finder": "^2.7|^3.0",
+	"ext-Fileinfo": "*"
     },
     "require-dev": {
         "bex/behat-test-runner": "^1.2.1",


### PR DESCRIPTION
It's used in `src/Bex/Behat/ScreenshotExtension/Driver/Local.php`. If your
php-version doesn't have the extension installed, you'll run into an error
otherwise. Because the error requires some effort to be tracked down, it
is now declared as a requirement in composer.json.

That way, composer will report the missing extension.