### PR TITLE
Fix typo in ScreenshotListener::shouldSaveScreenshot()

### DIFF
--- a/src/Bex/Behat/ScreenshotExtension/Listener/ScreenshotListener.php
+++ b/src/Bex/Behat/ScreenshotExtension/Listener/ScreenshotListener.php
@@ -116,9 +116,9 @@ final class ScreenshotListener implements EventSubscriberInterface
     private function shouldSaveScreenshot(AfterTested $event)
     {
         $hasScreenshot = $this->screenshotTaker->hasScreenshot();
-        $isScanerioFailed = $event->getTestResult()->getResultCode() === TestResult::FAILED;
+        $isScenarioFailed = $event->getTestResult()->getResultCode() === TestResult::FAILED;
         $shouldRecordAllScenarios = $this->config->shouldRecordAllScenarios();
 
-        return $hasScreenshot && ($isScanerioFailed || $shouldRecordAllScenarios);
+        return $hasScreenshot && ($isScenarioFailed || $shouldRecordAllScenarios);
     }
 }


### PR DESCRIPTION
Found a small typo in a variable name in `shouldSaveScreenshot()`.