### PR TITLE
Take screenshot for all steps only if enabled

### DIFF
--- a/features/screenshot-combining.feature
+++ b/features/screenshot-combining.feature
@@ -22,26 +22,103 @@ Feature: Taking screenshot
     When I run Behat
     Then I should see the message 'Permissible values: "failed_steps", "failed_scenarios", "all_scenarios"'
 
-    # We are not able to test this scenario on hhvm, because imagick can't be disabled
-    @skiphhvm
-    Scenario: It reports an error when ImageMagick is not installed
-      Given I have the configuration:
-        """
-        default:
-          extensions:
-            Behat\MinkExtension:
-              base_url: 'http://localhost:8080'
-              sessions:
-                default:
-                  selenium2:
-                    wd_host: http://localhost:4444/wd/hub
-                    browser: phantomjs
+  # We are not able to test this scenario on hhvm, because imagick can't be disabled
+  @skiphhvm
+  Scenario: It reports an error when ImageMagick is not installed
+    Given I have the configuration:
+      """
+      default:
+        extensions:
+          Behat\MinkExtension:
+            base_url: 'http://localhost:8080'
+            sessions:
+              default:
+                selenium2:
+                  wd_host: http://localhost:4444/wd/hub
+                  browser: phantomjs
 
-            Bex\Behat\ScreenshotExtension:
-              screenshot_taking_mode: failed_scenarios
-        """
-      When I run Behat
-      Then I should see the message "Imagemagick PHP extension is required, but not installed."
+          Bex\Behat\ScreenshotExtension:
+            screenshot_taking_mode: failed_scenarios
+      """
+    When I run Behat
+    Then I should see the message "Imagemagick PHP extension is required, but not installed."
+
+  Scenario: It creates a single screenshot of the faild step if the screenshot_taking_mode is "failed_steps" (default)
+    Given I have a web server running on host "localhost" and port "8080"
+    And I have the file "index.html" in document root:
+      """
+      <!DOCTYPE html>
+      <html>
+          <head>
+              <meta charset="UTF-8">
+              <title>Test page</title>
+              <style>
+                  body {background-color: #a9a9a9;}
+              </style>
+          </head>
+
+          <body>
+              <h1>Lorem ipsum dolor amet.</h1>
+          </body>
+      </html>
+      """
+    And I have the feature:
+      """
+      Feature: Multi-step feature
+      Scenario:
+        Given I have a failing step
+      Scenario:
+        Given I have a step
+        When I have another failing step
+        Then I should have a skipped step
+      """
+    And I have the context:
+      """
+      <?php
+      use Behat\MinkExtension\Context\RawMinkContext;
+      class FeatureContext extends RawMinkContext
+      {
+          /**
+           * @Given I have a step
+           */
+          function passingStep()
+          {
+            $this->visitPath('index.html');
+          }
+          /**
+           * @When I have a failing step
+           * @When I have another failing step
+           */
+          function failingStep()
+          {
+            $this->visitPath('index.html');
+            throw new Exception('Error');
+          }
+          /**
+           * @Then I should have a skipped step
+           */
+          function skippedStep()
+          {}
+      }
+      """
+    And I have the configuration:
+      """
+      default:
+        extensions:
+          Behat\MinkExtension:
+            base_url: 'http://localhost:8080'
+            sessions:
+              default:
+                selenium2:
+                  wd_host: http://localhost:4444/wd/hub
+                  browser: phantomjs
+
+          Bex\Behat\ScreenshotExtension:
+            screenshot_taking_mode: failed_steps
+      """
+    When I run Behat
+    Then I should have "%temp-dir%/behat-screenshot/features_feature_feature_2.png" image containing 1 step
+    And I should have "%temp-dir%/behat-screenshot/features_feature_feature_4.png" image containing 1 step
   
   # imagick is not up-to-date on hhvm
   @skiphhvm

--- a/spec/Bex/Behat/ScreenshotExtension/Listener/ScreenshotListenerSpec.php
+++ b/spec/Bex/Behat/ScreenshotExtension/Listener/ScreenshotListenerSpec.php
@@ -77,6 +77,7 @@ class ScreenshotListenerSpec extends ObjectBehavior
     }
 
     function it_takes_a_screenshot_after_a_passed_step(
+        Config $config,
         ScreenshotTaker $screenshotTaker,
         Environment $env,
         FeatureNode $feature,
@@ -91,8 +92,32 @@ class ScreenshotListenerSpec extends ObjectBehavior
             $result->getWrappedObject(),
             $tearDown->getWrappedObject()
         );
+        $config->shouldRecordAllSteps()->willReturn(true);
         $result->getResultCode()->willReturn(TestResult::PASSED);
         $screenshotTaker->takeScreenshot()->shouldBeCalled();
+
+        $this->takeScreenshot($event);
+    }
+
+    function it_does_not_take_a_screenshot_after_a_passed_step_if_not_enabled(
+        Config $config,
+        ScreenshotTaker $screenshotTaker,
+        Environment $env,
+        FeatureNode $feature,
+        StepNode $step,
+        StepResult $result,
+        Teardown $tearDown
+    ) {
+        $event = new AfterStepTested(
+            $env->getWrappedObject(),
+            $feature->getWrappedObject(),
+            $step->getWrappedObject(),
+            $result->getWrappedObject(),
+            $tearDown->getWrappedObject()
+        );
+        $config->shouldRecordAllSteps()->willReturn(false);
+        $result->getResultCode()->willReturn(TestResult::PASSED);
+        $screenshotTaker->takeScreenshot()->shouldNotBeCalled();
 
         $this->takeScreenshot($event);
     }

--- a/src/Bex/Behat/ScreenshotExtension/Listener/ScreenshotListener.php
+++ b/src/Bex/Behat/ScreenshotExtension/Listener/ScreenshotListener.php
@@ -107,7 +107,11 @@ final class ScreenshotListener implements EventSubscriberInterface
      */
     private function shouldTakeScreenshot(AfterTested $event)
     {
-        return $event->getTestResult()->getResultCode() !== TestResult::SKIPPED;
+        $isStepFailed = $event->getTestResult()->getResultCode() == TestResult::FAILED;
+        $isStepSkipped = $event->getTestResult()->getResultCode() == TestResult::SKIPPED;
+        $shouldRecordAllSteps = $this->config->shouldRecordAllSteps();
+
+        return $isStepFailed || (!$isStepSkipped && $shouldRecordAllSteps);
     }
 
     /**

--- a/src/Bex/Behat/ScreenshotExtension/ServiceContainer/Config.php
+++ b/src/Bex/Behat/ScreenshotExtension/ServiceContainer/Config.php
@@ -105,6 +105,14 @@ class Config
     }
 
     /**
+     * @return boolean
+     */
+    public function shouldRecordAllSteps()
+    {
+        return $this->screenshotTakingMode != self::SCREENSHOT_TAKING_MODE_FAILED_STEPS;
+    }
+
+    /**
      * Init service container and load image drivers
      * 
      * @param  ContainerBuilder $container


### PR DESCRIPTION
Take screenshot only if the `screenshot_taking_mode` is not `failed_steps`. In this way if the extension is used with the default config it will take screenshot only about the failed step and will prevent memory limit issues (see #31)