### PR TITLE
Hotfix/hhvm setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ cache:
 
 before_install:
   - composer self-update
+  - pear config-set preferred_state beta
+  - pecl channel-update pecl.php.net
+  - yes | pecl install imagick
 
 install:
   - composer install --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 sudo: false
 
-php: [5.4, 5.5, 5.6, 7.0, hhvm]
+php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2, hhvm]
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 sudo: false
 
-php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2, hhvm]
+php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2]
 
 matrix:
   fast_finish: true
@@ -13,15 +13,14 @@ cache:
 
 before_install:
   - composer self-update
-  - bash -c '[ ${TRAVIS_PHP_VERSION} == "hhvm" ] || printf "\n" | pecl install imagick'
 
 install:
   - composer install --no-interaction --prefer-source
 
 before_script:
-  - bash -c '[ ${TRAVIS_PHP_VERSION} == "hhvm" ]' || sed -i 's/extension="imagick.so"//g' ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - sed -i 's/extension="imagick.so"//g' ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 script:
   - bin/phpspec run --no-interaction --format=pretty
   - bin/phantomjs --webdriver=4444 &
-  - bash -c '[ ${TRAVIS_PHP_VERSION} == "hhvm" ]' && bin/behat --no-interaction --no-snippets --stop-on-failure --format=pretty --profile=travis-ci --tags='~@skiphhvm' || bin/behat --no-interaction --no-snippets --stop-on-failure --format=pretty --profile=travis-ci
+  - bin/behat --no-interaction --no-snippets --stop-on-failure --format=pretty --profile=travis-ci

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Behat-ScreenshotExtension
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/elvetemedve/behat-screenshot/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/elvetemedve/behat-screenshot/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/elvetemedve/behat-screenshot/badges/build.png?b=master)](https://scrutinizer-ci.com/g/elvetemedve/behat-screenshot/build-status/master)
 [![Build Status](https://travis-ci.org/elvetemedve/behat-screenshot.svg?branch=master)](https://travis-ci.org/elvetemedve/behat-screenshot)
-[![HHVM Status](http://hhvm.h4cc.de/badge/bex/behat-screenshot.svg?style=flat)](http://hhvm.h4cc.de/package/bex/behat-screenshot) <sup>[1]</sup>
 
 Behat-ScreenshotExtension helps you debug Behat scenarios by taking screenshot of the failing steps.
 

--- a/features/screenshot-combining.feature
+++ b/features/screenshot-combining.feature
@@ -22,8 +22,6 @@ Feature: Taking screenshot
     When I run Behat
     Then I should see the message 'Permissible values: "failed_steps", "failed_scenarios", "all_scenarios"'
 
-  # We are not able to test this scenario on hhvm, because imagick can't be disabled
-  @skiphhvm
   Scenario: It reports an error when ImageMagick is not installed
     Given I have the configuration:
       """
@@ -120,8 +118,6 @@ Feature: Taking screenshot
     Then I should have "%temp-dir%/behat-screenshot/features_feature_feature_2.png" image containing 1 step
     And I should have "%temp-dir%/behat-screenshot/features_feature_feature_4.png" image containing 1 step
   
-  # imagick is not up-to-date on hhvm
-  @skiphhvm
   Scenario: It creates a combined screenshot of multiple steps if the scenario fails
     Given I have a web server running on host "localhost" and port "8080"
     And I have the file "index.html" in document root:
@@ -199,8 +195,6 @@ Feature: Taking screenshot
     Then I should have "%temp-dir%/behat-screenshot/features_feature_feature_2.png" image containing 1 step
     And I should have "%temp-dir%/behat-screenshot/features_feature_feature_4.png" image containing 2 steps
 
-  # imagick is not up-to-date on hhvm
-  @skiphhvm
   Scenario: It creates a combined screenshots for all screnarios
     Given I have a web server running on host "localhost" and port "8080"
     And I have the file "index.html" in document root:


### PR DESCRIPTION
Changelog

- Drop HHVM support and remove related test configuration.
- Fix installing Imagemagick on Ubuntu.
- Add PHP `7.1` and `7.2` versions to Travis CI tests.