### PR TITLE
Allow to use paths.base in screenshot directory config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/finder": "^2.7|^3.0|^4.0"
     },
     "require-dev": {
-        "bex/behat-test-runner": "^1.2.1",
+        "bex/behat-test-runner": "^1.2.2",
         "phpspec/phpspec": "^2.5",
         "jakoch/phantomjs-installer": "^2.1.1-p07",
         "behat/mink-selenium2-driver": "^1.3.0",

--- a/features/bootstrap/ScreenshotContext.php
+++ b/features/bootstrap/ScreenshotContext.php
@@ -118,7 +118,10 @@ class ScreenshotContext implements SnippetAcceptingContext
      */
     private function substituteParameters($text)
     {
-        return str_replace('%temp-dir%', sys_get_temp_dir(), $text);
+        $text = str_replace('%temp-dir%', sys_get_temp_dir(), $text);
+        $text = str_replace('%working-dir%', $this->testRunnerContext->getWorkingDirectory(), $text);
+
+        return $text;
     }
 
     /**

--- a/features/screenshot-taking.feature
+++ b/features/screenshot-taking.feature
@@ -154,6 +154,29 @@ Feature: Taking screenshot
     And I should see the message "Screenshot has been taken. Open image at /tmp/behat-screenshot-custom/features_feature_feature_2.png"
     And I should have the image file "/tmp/behat-screenshot-custom/features_feature_feature_2.png"
 
+  Scenario: Save screenshot into a custom local directory using base path
+    Given I have the configuration:
+      """
+      default:
+        extensions:
+          Behat\MinkExtension:
+            base_url: 'http://localhost:8080'
+            sessions:
+              default:
+                selenium2:
+                  wd_host: http://localhost:4444/wd/hub
+                  browser: phantomjs
+
+          Bex\Behat\ScreenshotExtension:
+            image_drivers:
+              local:
+                screenshot_directory: %paths.base%/behat-screenshot-custom/
+      """
+    When I run Behat
+    Then I should see a failing test
+    And I should see the message "Screenshot has been taken. Open image at %working-dir%/behat-screenshot-custom/features_feature_feature_2.png"
+    And I should have the image file "%working-dir%/behat-screenshot-custom/features_feature_feature_2.png"
+
   Scenario: Save screenshot using external driver
     Given I have the configuration:
       """

--- a/src/Bex/Behat/ScreenshotExtension/Driver/Local.php
+++ b/src/Bex/Behat/ScreenshotExtension/Driver/Local.php
@@ -86,7 +86,11 @@ class Local implements ImageDriverInterface
      */
     public function load(ContainerBuilder $container, array $config)
     {
-        $this->screenshotDirectory = $config[self::CONFIG_PARAM_SCREENSHOT_DIRECTORY];
+        $this->screenshotDirectory = str_replace(
+            '%paths.base%',
+            $container->getParameter('paths.base'),
+            $config[self::CONFIG_PARAM_SCREENSHOT_DIRECTORY]
+        );
 
         if ($config[self::CONFIG_PARAM_CLEAR_SCREENSHOT_DIRECTORY]) {
             $this->fileInfo = $this->fileInfo ?: new \finfo();


### PR DESCRIPTION
Related issue: https://github.com/elvetemedve/behat-screenshot/issues/46