### PR TITLE
Only take a screenshot when a session is started

### DIFF
--- a/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
+++ b/src/Bex/Behat/ScreenshotExtension/Service/ScreenshotTaker.php
@@ -50,6 +50,9 @@ class ScreenshotTaker
     public function takeScreenshot()
     {
         try {
+            if (!$this->mink->getSession()->isStarted()) {
+                return;
+            }
             $this->screenshots[] = $this->mink->getSession()->getScreenshot();
         } catch (UnsupportedDriverActionException $e) {
             return;


### PR DESCRIPTION
This extension currently tries to take a screenshot whenever a step fails, even if that step fails because a session can't be started due to a driver failure. This causes the scenario in question to be skipped instead of failing, resulting in false positives.