### PR TITLE
[Fix build] Limit behat version to 3.5.x because of BC break in 3.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 sudo: false
 
-php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2]
+php: [5.6, 7.0, 7.1, 7.2]
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "behat/behat": "^3.0.0",
+        "behat/behat": "^3.0.0 <3.6",
         "behat/mink-extension": "^2.0.0",
         "bex/behat-extension-driver-locator": "^1.0.2",
         "symfony/filesystem": "^2.7|^3.0|^4.0",


### PR DESCRIPTION
in Behat 3.6 they started to use `::class` which is a php 5.5 feature but they forgot to update the minimum php version requirement of the package therefore it is breaking the build when using 3.6.x behat

with this we will limit the behat version to 3.5.x then we can create a release, then we can remove this limitation in 2.0.0 and drop support for php 5.4

see https://github.com/Behat/Behat/pull/1284