### PR TITLE
New major version - allow behat 3.6+ by increasing min php version to 5.5

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -28,7 +28,7 @@ filter:
 build:
     environment:
         php:
-            version: 5.4
+            version: 5.5
             ini:
                 'always_populate_raw_post_data': '-1'
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -36,8 +36,6 @@ build:
         override:
             - bin/phpspec run --no-interaction --format=pretty
             - bin/behat --no-interaction --no-snippets --stop-on-failure --format=pretty
-        after:
-            - SCRUTINIZER_START_TIME=$(cat /tmp/build-start-time.txt) sh -c 'curl -sS https://gist.githubusercontent.com/tonypiper/fd3cf9a67b71d4e3928c/raw/152f1d873f98ff4256ca8bc3041443eae7c890b4/keenio-logger.php | php'
 
     dependencies:
         before:
@@ -47,7 +45,7 @@ build:
             - sed -i 's/extension="imagick.so"//g' `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 
         override:
-            - { command: 'composer install --no-interaction --prefer-source', idle_timeout: 600 }
+            - { command: 'composer install --no-interaction', idle_timeout: 600 }
 
     cache:
         directories: [ bin/, ~/.composer/cache ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - yes | pecl install imagick
 
 install:
-  - composer install --no-interaction --prefer-source
+  - composer install --no-interaction
 
 before_script:
   - sed -i 's/extension="imagick.so"//g' ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: php
 
 sudo: false
 
-php: [5.6, 7.0, 7.1, 7.2]
-
+php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, nightly]
 matrix:
-  fast_finish: true
+  allow_failures:
+    - php: nightly
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/finder": "^2.7|^3.0|^4.0"
     },
     "require-dev": {
-        "bex/behat-test-runner": "^1.2.2",
+        "bex/behat-test-runner": "1.3.1",
         "phpspec/phpspec": "^2.5",
         "jakoch/phantomjs-installer": "^2.1.1-p07",
         "behat/mink-selenium2-driver": "^1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/finder": "^2.7|^3.0|^4.0"
     },
     "require-dev": {
-        "bex/behat-test-runner": "1.3.1",
+        "bex/behat-test-runner": "^1.3.1",
         "phpspec/phpspec": "^2.5",
         "jakoch/phantomjs-installer": "^2.1.1-p07",
         "behat/mink-selenium2-driver": "^1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "behat/behat": "^3.0.0 <3.6",
+        "php": ">=5.5",
+        "behat/behat": "^3.0.0",
         "behat/mink-extension": "^2.0.0",
         "bex/behat-extension-driver-locator": "^1.0.2",
         "symfony/filesystem": "^2.7|^3.0|^4.0",


### PR DESCRIPTION
this is necessary because php >=5.5 missing from behat 3.6 (https://github.com/Behat/Behat/pull/1284)